### PR TITLE
Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5",
-        "mockery/mockery": "0.9.*"
+        "phpunit/phpunit": "^9.2",
+        "mockery/mockery": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AccountTest.php
+++ b/tests/AccountTest.php
@@ -3,9 +3,8 @@
 namespace Ampersa\Baremetrics\Tests;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
 
-class AccountTest extends PHPUnit_Framework_TestCase
+class AccountTest extends \PHPUnit\Framework\TestCase
 {
     /**
      *

--- a/tests/AnnotationsTest.php
+++ b/tests/AnnotationsTest.php
@@ -3,9 +3,8 @@
 namespace Ampersa\Baremetrics\Tests;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
 
-class AnnotationsTest extends PHPUnit_Framework_TestCase
+class AnnotationsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      *

--- a/tests/BaremetricsTest.php
+++ b/tests/BaremetricsTest.php
@@ -3,9 +3,8 @@
 namespace Ampersa\Baremetrics\Tests;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
 
-class BaremetricsTest extends PHPUnit_Framework_TestCase
+class BaremetricsTest extends \PHPUnit\Framework\TestCase
 {
     /**
      *

--- a/tests/MetricsTest.php
+++ b/tests/MetricsTest.php
@@ -4,9 +4,8 @@ namespace Ampersa\Baremetrics\Tests;
 
 use Mockery;
 use TypeError;
-use PHPUnit_Framework_TestCase;
 
-class MetricsTest extends PHPUnit_Framework_TestCase
+class MetricsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSummaryCallsCorrectEndpointAndReturnsExpected()
     {

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -3,9 +3,8 @@
 namespace Ampersa\Baremetrics\Tests;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
 
-class ResponseTest extends PHPUnit_Framework_TestCase
+class ResponseTest extends \PHPUnit\Framework\TestCase
 {
     /**
      *


### PR DESCRIPTION
fixes #3 

- Bump guzzle to ^7.0
- Bump phpunit/phpunit to ^9.2
- Bump mockery/mockery to ^1.0
- fix tests